### PR TITLE
Fix unicode bug in argument handling

### DIFF
--- a/STPrivilegedTask.m
+++ b/STPrivilegedTask.m
@@ -187,10 +187,11 @@ OSStatus const errAuthorizationFnNoLongerExists = -70001;
     // first, construct an array of c strings from NSArray w. arguments
     for (int i = 0; i < numberOfArguments; i++) {
         NSString *argString = arguments[i];
-        NSUInteger stringLength = [argString length];
+        const char *fsrep = [argString fileSystemRepresentation];
+        NSUInteger stringLength = strlen(fsrep);
         
         args[i] = malloc((stringLength + 1) * sizeof(char));
-        snprintf(args[i], stringLength + 1, "%s", [argString fileSystemRepresentation]);
+        snprintf(args[i], stringLength + 1, "%s", fsrep);
     }
     args[numberOfArguments] = NULL;
     


### PR DESCRIPTION
When constructing an array of c strings from the NSArray of arguments,
for strings with non-ascii characters `[argString length]` differs from
the byte count of `[argString fileSystemRepresentation]`, which caused
argument strings to be truncated. This changes it to use `strlen` on
the `fileSystemRepresentation` for size calculation.